### PR TITLE
Key transformers

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -150,7 +150,7 @@ describe('validation', () => {
 
     expect(!notOkValidation2.isOk() && notOkValidation2.get().length).toBe(3)
     printErrorMessage(notOkValidation2)
-  })  
+  })
 
   it('can be recursive', () => {
     type Category = { name: string, categories: Category[] }
@@ -319,7 +319,63 @@ describe('validation', () => {
     printErrorMessage(notOkValidation3)
   })
 
-  
+
+  it('can transform snake cased inputs into camel case before validating', () => {
+
+    const burger = v.object({
+      id: v.number,
+      meatCooking: v.string,
+      awesomeSides: v.array(v.string)
+    })
+
+    const okSnakeCased = burger.validate({
+      id: 123,
+      'meat_cooking': 'rare',
+      'awesome_sides': [ 'loaded fries', 'barbecue sauce' ]
+    }, { transformer: v.snakeCaseTransformer })
+
+    expect(okSnakeCased.isOk()).toBe(true)
+  })
+
+  it('report transformed field names to the user in case of error', () => {
+
+    const burger = v.object({
+      id: v.number,
+      meatCooking: v.string,
+      awesomeSides: v.array(v.string)
+    })
+
+    const fieldInError = burger.validate({
+      id: 123,
+      'meat_cooking': 42,
+      'awesome_sides': [ 'loaded fries', 'barbecue sauce' ]
+    }, { transformer: v.snakeCaseTransformer })
+
+    expect(fieldInError.isOk()).toBe(false)
+
+    if(!fieldInError.isOk()) {
+      const { context } = fieldInError.get()[0]
+      expect(context).toEqual('root / meat_cooking')
+    }
+  })
+
+  it('should be strict on input casing when using a transformer', () => {
+
+    const burger = v.object({
+      id: v.number,
+      meatCooking: v.string,
+      awesomeSides: v.array(v.string)
+    })
+
+    const errorCamelCased = burger.validate({
+      id: 456,
+      meatCooking: 'blue',
+      awesomeSides: [ 'potatoes', 'ketchup' ]
+    }, { transformer: v.snakeCaseTransformer })
+
+    expect(errorCamelCased.isOk()).toBe(false)
+
+  })
 
 })
 


### PR DESCRIPTION
This pull request adds an optional configuration object that allows the user to specify additional behaviors when validating inputs : key renaming in this case.

It's often the case that JSON data has a different naming convention (often snake case) than the one used in the codebase manipulating that JSON (often camel case in my case).

With the new `transformer` parameter that can be specified in the configuration object, one can specify the key transformation that an object validator has to do on its own keys before actually reading the fields from the input.