### PR TITLE
fix meta tags for dictionary and discriminated union

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -450,6 +450,7 @@ export function dictionary<K extends string, V>(
 
   validator.meta.tag = 'dictionary'
   validator.meta.value = codomain
+  validator.meta.key = domain
 
   return validator
 }
@@ -675,7 +676,9 @@ export function discriminatedUnion<
     return validator.validate(v, context, p)
   })
 
+  discriminated.meta.discriminatedUnion = vs
   discriminated.meta.tag = 'discriminatedUnion'
+  discriminated.meta.typeKey = typeKey
 
   return discriminated
 }


### PR DESCRIPTION
The aim of this fix is to improve meta tagging for **dictionary** and **discriminatedUnion** validators.
 